### PR TITLE
Update TickTick to 1.0.11

### DIFF
--- a/com.ticktick.TickTick.metainfo.xml
+++ b/com.ticktick.TickTick.metainfo.xml
@@ -77,6 +77,7 @@
     </screenshot>
   </screenshots>
   <releases>
+    <release version="1.0.11" date="2022-05-10"/>
     <release version="0.0.5" date="2022-01-12"/>
   </releases>
   <content_rating type="oars-1.1"/>

--- a/com.ticktick.TickTick.yml
+++ b/com.ticktick.TickTick.yml
@@ -46,16 +46,16 @@ modules:
         only-arches:
           - x86_64
         filename: ticktick.deb
-        url: https://appest-public.s3.amazonaws.com/download/linux/linux_deb_x64/ticktick-0.0.5-amd64.deb
-        sha256: bb84fcce2ffa35d4c087fdb03e71cd772d1d6a5a255d65d8d988ce5affc67cce
-        size: 82933300
+        url: https://appest-public.s3.amazonaws.com/download/linux/linux_deb_x64/ticktick-1.0.11-amd64.deb
+        sha256: 04fa5b48213719fdb79eaa5515908ff2a1b37f0233ae44cc96530919ef2827b2
+        size: 83179106
       - type: extra-data
         only-arches:
           - aarch64
         filename: ticktick.deb
-        url: https://appest-public.s3.amazonaws.com/download/linux/linux_deb_arm64/ticktick-0.0.5-arm64.deb
-        sha256: 980f7dfe74e1f174dad29d15344c57a33fc2c8213be37c0f613a74e732323d26
-        size: 82789188
+        url: https://appest-public.s3.amazonaws.com/download/linux/linux_deb_arm64/ticktick-1.0.11-arm64.deb
+        sha256: 006284bc77173174578ce9f8b0e1192ad35bcacef6ad6fb1b904bee679cb0a44
+        size: 83049894
       - type: file
         path: icons/com.ticktick.TickTick-16.png
       - type: file


### PR DESCRIPTION
Update TickTick sources to latest release, 1.0.11.

Tested briefly on the following system and everything seems fine:
- Fedora Linux 36 (GNOME 42.1)
- NVIDIA Proprietary Drivers on X11
