### PR TITLE
Remove org.freedesktop.Notifications bus access

### DIFF
--- a/com.ticktick.TickTick.yml
+++ b/com.ticktick.TickTick.yml
@@ -18,7 +18,6 @@ finish-args:
   - --socket=pulseaudio
   - --share=network
   - --talk-name=org.freedesktop.secrets
-  - --talk-name=org.freedesktop.Notifications
   - --talk-name=org.kde.StatusNotifierWatcher
 
 modules:


### PR DESCRIPTION
The electron baseapp has libnotify 0.8 which uses the portal for notifications, so this is no longer required

See https://gitlab.gnome.org/GNOME/libnotify/-/blob/69aff6e5fa2842e00b409c348bd73188548828b3/NEWS#L25