### PR TITLE
ticktick: Update ticktick.deb to 6.0.40

### DIFF
--- a/com.ticktick.TickTick.metainfo.xml
+++ b/com.ticktick.TickTick.metainfo.xml
@@ -77,8 +77,11 @@
     </screenshot>
   </screenshots>
   <releases>
-    <release version="6.0.30" date="2025-03-24">
+    <release version="6.0.40" date="2025-07-16">
       <description></description>
+    </release>
+    <release version="6.0.30" date="2025-03-24">
+      <description/>
     </release>
     <release version="6.0.21" date="2025-01-16">
       <description/>

--- a/com.ticktick.TickTick.yml
+++ b/com.ticktick.TickTick.yml
@@ -45,9 +45,9 @@ modules:
         only-arches:
           - x86_64
         filename: ticktick.deb
-        url: https://d2atcrkye2ik4e.cloudfront.net/download/linux/linux_deb_x64/ticktick-6.0.30-amd64.deb
-        sha256: c533506f2dca665a3741033916a10a5d8cc062aea3816c0def38d817697afbbf
-        size: 102325602
+        url: https://d2atcrkye2ik4e.cloudfront.net/download/linux/linux_deb_x64/ticktick-6.0.40-amd64.deb
+        sha256: d1e06c0ffa8509a2bf22cbb85c956f7bef1306cb202c0b0208cd461cddb73c89
+        size: 104992200
         x-checker-data:
           type: rotating-url
           url: https://ticktick.com/static/getApp/download?type=linux_deb_x64
@@ -56,9 +56,9 @@ modules:
         only-arches:
           - aarch64
         filename: ticktick.deb
-        url: https://d2atcrkye2ik4e.cloudfront.net/download/linux/linux_deb_arm64/ticktick-6.0.30-arm64.deb
-        sha256: 32558e0a4934772615e22c8f4ecfc9b6af84f50a6c8b3a1ed971a63e58eb6a10
-        size: 97662824
+        url: https://d2atcrkye2ik4e.cloudfront.net/download/linux/linux_deb_arm64/ticktick-6.0.40-arm64.deb
+        sha256: 5122a6c9d8b2798f0889b7be79b706726c28ed7244c3f1047ff398e0fb12ae5f
+        size: 100334184
         x-checker-data:
           type: rotating-url
           url: https://ticktick.com/static/getApp/download?type=linux_deb_arm64


### PR DESCRIPTION
Resolves #27 