### PR TITLE
Fix StartupWMClass case to match actual WM_CLASS

### DIFF
--- a/com.ticktick.TickTick.desktop
+++ b/com.ticktick.TickTick.desktop
@@ -4,6 +4,6 @@ Exec=ticktick %U
 Terminal=false
 Type=Application
 Icon=com.ticktick.TickTick
-StartupWMClass=TickTick
+StartupWMClass=ticktick
 Comment=TickTick is a powerful to-do & task management app with seamless cloud synchronization across all your devices. Whether you need to schedule an agenda, make memos, share shopping lists, collaborate in a team, or even develop a new habit, TickTick is always here to help you get stuff done and keep life on track.
 Categories=Office;


### PR DESCRIPTION
The desktop file has `StartupWMClass=TickTick` but the app actually reports `WM_CLASS = "ticktick"` (all lowercase) at runtime.

This mismatch causes GNOME Shell to not associate the running window with the launcher, which results in a second taskbar/dock entry appearing with a generic blue application icon when TickTick is launched.

Fix is to lowercase the value to match what the app actually reports, confirmed via `xprop WM_CLASS`.

Tested on Fedora Silverblue 44 with GNOME 50.