### PR TITLE
Re-enable `--socket=wayland` on app manifest

### DIFF
--- a/com.ticktick.TickTick.yml
+++ b/com.ticktick.TickTick.yml
@@ -11,8 +11,8 @@ tags:
   - proprietary
 
 finish-args:
-  - --socket=x11
   - --socket=wayland
+  - --socket=fallback-x11
   - --device=dri
   - --share=ipc
   - --socket=pulseaudio

--- a/com.ticktick.TickTick.yml
+++ b/com.ticktick.TickTick.yml
@@ -12,7 +12,7 @@ tags:
 
 finish-args:
   - --socket=x11
-  # - --socket=wayland
+  - --socket=wayland
   - --device=dri
   - --share=ipc
   - --socket=pulseaudio


### PR DESCRIPTION
The latest version of the Electron app looks for a Wayland socket on supported systems, which now fails on the socket arg that was removed 4 years ago.

This PR re-enables `--socket=wayland` in parallel with `--socket=fallback-x11` (standard convention to have both for supported Flatpaks as far as I can tell).  Can confirm this resolves https://github.com/flathub/com.ticktick.TickTick/issues/38 for me.